### PR TITLE
corrected CDN script tag version

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script id="roboflowScript" src="https://cdn.roboflow.com/0.2.20/roboflow.js"></script>
+    <script id="roboflowScript" src="https://cdn.roboflow.com/0.2.26/roboflow.js"></script>
     <title>🤝 Roboflow</title>
   </head>
   <body>


### PR DESCRIPTION
# Description
Roboflow CDN script tag was outdated (version 0.2.20 -> 0.2.26)


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Yes, I cloned the repo, and it doesn't work without making this change

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes: N/A
